### PR TITLE
Make router a required parameter in configuration

### DIFF
--- a/src/main/java/Routes/Router.java
+++ b/src/main/java/Routes/Router.java
@@ -10,5 +10,6 @@ public interface Router {
     public byte[] direct(Request request) throws IOException;
     public void setRoutes(ArrayList<Route> routes);
     public void setDirectoryLocation(String location);
+    public boolean isRoutes();
 
 }

--- a/src/main/java/configuration/Configuration.java
+++ b/src/main/java/configuration/Configuration.java
@@ -15,7 +15,11 @@ public class Configuration {
     private ArrayList<Route> routes = new ArrayList<Route>();
     private Router router;
 
+    public Configuration(Router router) {
+        this.router = router;
+    }
 
+    public int getPort() {return port;}
     public void setPort(int port) {
                                 this.port = port;
                                                  }
@@ -23,10 +27,6 @@ public class Configuration {
     public void addRoute(String path, Controller controller) {
         Route route = new Route(path, controller);
         routes.add(route);
-    }
-
-    public void setRouter(Router router) {
-        this.router = router;
     }
 
     public void setRoutes() {

--- a/src/main/java/routes/FileRouter.java
+++ b/src/main/java/routes/FileRouter.java
@@ -29,6 +29,10 @@ public class FileRouter implements Router {
         }
     }
 
+    public boolean isRoutes() {
+        return !routes.isEmpty();
+    }
+
     public byte[] direct(Request request) throws IOException {
         byte[] response;
         Optional<Route> route = findRoute(request.getPath());

--- a/src/main/java/runnables/RunnableRequestResponse.java
+++ b/src/main/java/runnables/RunnableRequestResponse.java
@@ -29,7 +29,9 @@ public class RunnableRequestResponse implements Runnable{
             Request request = parser.parseAndCreateRequest(socket.getInputStream());
             synchronized (router) {
                 router.setDirectoryLocation(directoryLocation);
-                router.setRoutes(null);
+                if (!router.isRoutes()) {
+                    router.setRoutes(null);
+                }
                 byte[] response = router.direct(request);
                 socket.getOutputStream().write(response);
                 socket.close();

--- a/src/test/java/configuration/ConfigurationTest.java
+++ b/src/test/java/configuration/ConfigurationTest.java
@@ -1,0 +1,42 @@
+import configuration.Configuration;
+import org.junit.Before;
+import org.junit.Test;
+import requests.Request;
+import routes.Route;
+import routes.Router;
+
+import java.util.ArrayList;
+
+import static junit.framework.TestCase.assertEquals;
+
+public class ConfigurationTest {
+    private Configuration config;
+    @Before
+    public void setUp() {
+        config = new Configuration(new MockRouter());
+    }
+
+    @Test
+    public void setsPortCorrectly() {
+        config.setPort(4000);
+        assertEquals(4000, config.getPort());
+    }
+
+    private class MockRouter implements Router {
+        public void setRoutes(ArrayList<Route> routes)  {
+        }
+
+        public void setDirectoryLocation(String location) {
+        }
+
+        public byte[] direct(Request request) {
+            return new byte[4];
+        }
+
+        public boolean isRoutes() {
+            return true;
+        }
+
+    }
+
+}


### PR DESCRIPTION
There was temporal coupling with the routes and router

Also I am only setting the routes to the default cob spec routes if
no routes were set using the configuration file.
